### PR TITLE
WIP: Build Pipelines #2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ clone_depth: 1
 build_script:
   - mkdir build
   - cd build
-  - cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=/c/Qt/5.13.1/msvc2017_64 ..
+  - cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=C:\Qt\5.13.1\msvc2017_64 ..
   - cmake --build . --config Release
 artifacts:
 - path: build/build/Release/RcloneBrowser.exe

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,10 @@
 version: '#{build}'
 image: 'Visual Studio 2019'
+- provider: Environment
+  name: production
+  on:
+    APPVEYOR_REPO_TAG: true
+
 branches:
   only:
   - master
@@ -13,4 +18,18 @@ build_script:
 artifacts:
 - path: build/build/Release/RcloneBrowser.exe
 test: off
+
 deploy: off
+#deploy:
+#  release: "Rclone Browser $(APPVEYOR_REPO_TAG_NAME)"
+#  description: 'Release description'
+#  provider: GitHub
+#  auth_token:
+#    secure: r encrypted token> # your encrypted token from GitHub
+#  artifact: /.*\.exe/            # upload all NuGet packages to release assets
+#  draft: false
+#  prerelease: false
+#  on:
+#    branch: master                 # release from master branch only
+#    APPVEYOR_REPO_TAG: true        # deploy on tag push only
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,107 @@
+---
+# Github Actions build for rclone
+# -*- compile-command: "yamllint -f parsable build.yml" -*-
+
+name: build
+
+# Trigger the workflow on push or pull request
+on:
+  push:
+    #tags:
+    #  - v*
+    branch:
+      - '*'
+
+
+jobs:
+  build:
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        #job_name: ['linux', 'mac', 'windows_amd64' ]
+        job_name: ['linux', 'mac' ]
+
+        include:
+          - job_name: linux
+            os: ubuntu-latest
+
+          - job_name: mac
+            os: macOS-latest
+
+            #- job_name: windows_amd64
+            #  os: windows-latest
+            #  modules: 'off'
+            #  build_flags: '-include "^windows/amd64" -cgo'
+            #  quicktest: true
+            #  racequicktest: true
+            #  deploy: true
+
+    name: ${{ matrix.job_name }}
+
+    runs-on: ${{ matrix.os }}
+
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          path: ./src/github.com/${{ github.repository }}
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v1
+        with:
+          version: 5.13.1
+
+      - name: Install Libraries on Linux
+        shell: bash
+        run: |
+          sudo apt-get install git rclone g++ cmake qtbase5-dev
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Install Libraries on macOS
+        shell: bash
+        run: |
+          echo '::set-env name=PATH::/usr/local/opt/qt/bin'
+          echo '::set-env name=LDFLAGS::-L/usr/local/opt/qt/lib'
+          echo '::set-env name=CPPFLAGS::-I/usr/local/opt/qt/include'
+          echo '::set-env name=PKG_CONFIG_PATH::/usr/local/opt/qt/lib/pkgconfig'
+          brew update
+          brew install git cmake rclone qt5
+        if: matrix.os == 'macOS-latest'
+
+        #- name: Install Libraries on Windows
+        #  shell: powershell
+        #  run: |
+        #    $ProgressPreference = 'SilentlyContinue'
+        #    choco install -y winfsp zip
+        #    # Copy mingw32-make.exe to make.exe so the same command line
+        #    # can be used on Windows as on macOS and Linux
+        #    $path = (get-command mingw32-make.exe).Path
+        #    Copy-Item -Path $path -Destination (Join-Path (Split-Path -Path $path) 'make.exe')
+        #  if: matrix.os == 'windows-latest'
+        #
+      - name: Debugging
+        shell: bash
+        run: |
+          pwd
+          ls -lahR
+
+      - name: Compile on Linux
+        shell: bash
+        run: |
+          mkdir build && cd build
+          cmake ..
+          cmake --build .
+
+      - name: Debugging
+        shell: bash
+        run: |
+          pwd
+          ls -lahR
+
+      - name: Package for macOS
+        shell: bash
+        run: |
+          macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,18 +57,18 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install git rclone g++ cmake
+          sudo apt-get install rclone cmake
         if: matrix.os == 'ubuntu-latest'
 
       - name: Install Libraries on macOS
         shell: bash
         run: |
-          echo '::set-env name=PATH::/usr/local/opt/qt/bin'
+          echo '::add-path::/usr/local/opt/qt/bin'
           echo '::set-env name=LDFLAGS::-L/usr/local/opt/qt/lib'
           echo '::set-env name=CPPFLAGS::-I/usr/local/opt/qt/include'
           echo '::set-env name=PKG_CONFIG_PATH::/usr/local/opt/qt/lib/pkgconfig'
           brew update
-          brew install git cmake rclone
+          brew install rclone
         if: matrix.os == 'macOS-latest'
 
         #- name: Install Libraries on Windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #job_name: ['linux', 'mac', 'windows_amd64' ]
-        job_name: ['linux', 'mac' ]
+        job_name: ['linux', 'mac', 'windows_amd64' ]
 
         include:
           - job_name: linux
@@ -31,11 +30,6 @@ jobs:
 
             #- job_name: windows_amd64
             #  os: windows-latest
-            #  modules: 'off'
-            #  build_flags: '-include "^windows/amd64" -cgo'
-            #  quicktest: true
-            #  racequicktest: true
-            #  deploy: true
 
     name: ${{ matrix.job_name }}
 
@@ -71,26 +65,77 @@ jobs:
           brew install rclone
         if: matrix.os == 'macOS-latest'
 
-        #- name: Install Libraries on Windows
-        #  shell: powershell
-        #  run: |
-        #    $ProgressPreference = 'SilentlyContinue'
-        #    choco install -y winfsp zip
-        #    # Copy mingw32-make.exe to make.exe so the same command line
-        #    # can be used on Windows as on macOS and Linux
-        #    $path = (get-command mingw32-make.exe).Path
-        #    Copy-Item -Path $path -Destination (Join-Path (Split-Path -Path $path) 'make.exe')
-        #  if: matrix.os == 'windows-latest'
-        #
-      - name: Compile on Linux
+      - name: Install Libraries on Windows
+        shell: powershell
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          choco install -y rclone
+        if: matrix.os == 'windows-latest'
+
+      - name: Compile
         shell: bash
         run: |
           mkdir build && cd build
-          cmake ..
+          cmake .. -DCMAKE_BUILD_TYPE=Release
           cmake --build .
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Compile
+        shell: bash
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake --build .
+        if: matrix.os == 'macOS-latest'
+
+      - name: Compile on Windows
+        shell: powershell
+        run: |
+          mkdir build
+          cd build
+          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" ..
+          cmake --build . --config Release
+        if: matrix.os == 'windows-latest'
+
+      - name: Debugging
+        shell: bash
+        run: |
+          pwd
+          ls -lah
+          echo $Qt5_Dir
+          ls -lah build/
 
       - name: Package for macOS
         shell: bash
         run: |
-          macdeployqt rclone-browser.app -executable="build/rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
+          cd build
+          macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
+        if: matrix.os == 'macOS-latest'
 
+      - name: Debugging
+        shell: bash
+        run: |
+          pwd
+          ls -lah
+          ls -lah build/
+
+      - name: Upload artifacts Linux
+        uses: actions/upload-artifact@v1
+        with:
+          name: "rclone-browser-${{ github.ref }}-${{ github.sha  }}-amd64"
+          path: build/
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Upload artifacts macOS
+        uses: actions/upload-artifact@v1
+        with:
+          name: "rclone-browser-${{ github.ref }}-${{ github.sha  }}-macOS"
+          path: build/
+        if: matrix.os == 'macOS-latest'
+
+      - name: Upload artifacts Windows
+        uses: actions/upload-artifact@v1
+        with:
+          name: "rclone-browser-${{ github.ref }}-${{ github.sha }}-win64"
+          path: build/build/Release/RcloneBrowser.exe
+        if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install rclone cmake
+          sudo apt-get install rclone cmake libgl-dev
         if: matrix.os == 'ubuntu-latest'
 
       - name: Install Libraries on macOS
@@ -92,5 +92,5 @@ jobs:
       - name: Package for macOS
         shell: bash
         run: |
-          macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
+          macdeployqt rclone-browser.app -executable="build/rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Install Libraries on Linux
         shell: bash
         run: |
-          sudo apt-get install git rclone g++ cmake qtbase5-dev
+          sudo apt-get update
+          sudo apt-get install git rclone g++ cmake
         if: matrix.os == 'ubuntu-latest'
 
       - name: Install Libraries on macOS
@@ -67,7 +68,7 @@ jobs:
           echo '::set-env name=CPPFLAGS::-I/usr/local/opt/qt/include'
           echo '::set-env name=PKG_CONFIG_PATH::/usr/local/opt/qt/lib/pkgconfig'
           brew update
-          brew install git cmake rclone qt5
+          brew install git cmake rclone
         if: matrix.os == 'macOS-latest'
 
         #- name: Install Libraries on Windows
@@ -81,24 +82,12 @@ jobs:
         #    Copy-Item -Path $path -Destination (Join-Path (Split-Path -Path $path) 'make.exe')
         #  if: matrix.os == 'windows-latest'
         #
-      - name: Debugging
-        shell: bash
-        run: |
-          pwd
-          ls -lahR
-
       - name: Compile on Linux
         shell: bash
         run: |
           mkdir build && cd build
           cmake ..
           cmake --build .
-
-      - name: Debugging
-        shell: bash
-        run: |
-          pwd
-          ls -lahR
 
       - name: Package for macOS
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
           - job_name: mac
             os: macOS-latest
 
-            #- job_name: windows_amd64
-            #  os: windows-latest
+          - job_name: windows_amd64
+            os: windows-latest
 
     name: ${{ matrix.job_name }}
 


### PR DESCRIPTION
I'm working on fixing the Appveyor Windows build and setting up GitHub Actions for the Linux and MacOS build.

The linux build completed, the mac build is still failing at the macdeployqt.

This could be easily set up to run builds only when you create tags for beta and final releases.

### How to test

* Builds of my test fork can be seen here: 
  * Linux/MacOS: https://github.com/danoe/RcloneBrowser/actions
  * Windows: https://ci.appveyor.com/project/danoe/rclonebrowser/history
* To test in your own fork, just merge this PR into any test branch
* For Windows builds an Appveyor account needs to be set up for now

### What's missing
* Fix macOS build
* Proper naming of the builds
* Creating signature for the builds
* GitHub Actions: automatic upload of the artifacts to GitHub Release page
* Appveyor: automatic upload of the artifacts to GitHub Release page
* Optional: moving Windows build from Appveyor to GitHub Actions