### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,15 @@ matrix:
         apt:
           packages:
             - qttools5-dev
+    #powerjob
+    - os: linux
+      arch: ppc64le
+      language: cpp
+      sudo: false
+      addons:
+        apt:
+          packages:
+            - qttools5-dev           
       script:
         - mkdir build && cd build
         - cmake ..


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. 
Even though its failing for amd64.