### PR TITLE
Update `job_widget.cpp` to support rclone 1.56 output changes

### DIFF
--- a/src/job_widget.cpp
+++ b/src/job_widget.cpp
@@ -62,21 +62,26 @@ JobWidget::JobWidget(QProcess *process, const QString &info,
         R"(^Transferred:\s+(\S+ \S+) \(([^)]+)\)$)"); // Until rclone 1.42
     QRegExp rxSize2(
         R"(^Transferred:\s+([0-9.]+)(\S)? \/ (\S+) (\S+), ([0-9%-]+), (\S+ \S+), (\S+) (\S+)$)"); // Starting with rclone 1.43
-    QRegExp rxErrors(R"(^Errors:\s+(\S+)$)");
+    QRegExp rxSize3(
+        R"(^Transferred:\s+([0-9.]+ \w+) \/ ([0-9.]+ \w+), ([0-9%-]+), ([0-9.]+ \w+\/s), \w+ (\S+)$)"); // Starting with rclone 1.57
+    QRegExp rxErrors(
+        R"(^Errors:\s+(\d+)(.*)$)"); // captures also following variant:
+                                     // "Errors: 123 (bla bla bla)"
     QRegExp rxChecks(R"(^Checks:\s+(\S+)$)"); // Until rclone 1.42
     QRegExp rxChecks2(
         R"(^Checks:\s+(\S+) \/ (\S+), ([0-9%-]+)$)");   // Starting with
                                                         // rclone 1.43
     QRegExp rxTransferred(R"(^Transferred:\s+(\S+)$)"); // Until rclone 1.42
     QRegExp rxTransferred2(
-        R"(^Transferred:\s+(\S+) \/ (\S+), ([0-9%-]+)$)"); // Starting with
+        R"(^Transferred:\s+(\d+) \/ (\d+), ([0-9%-]+)$)"); // Starting with
                                                            // rclone 1.43
     QRegExp rxTime(R"(^Elapsed time:\s+(\S+)$)");
     QRegExp rxProgress(
         R"(^\*([^:]+):\s*([^%]+)% done.+(ETA: [^)]+)$)"); // Until rclone 1.38
     QRegExp rxProgress2(
         R"(\*([^:]+):\s*([^%]+)% \/[a-zA-z0-9.]+, [a-zA-z0-9.]+\/s, (\w+)$)"); // Starting with rclone 1.39
-
+    QRegExp rxProgress3(
+        R"(^\* ([^:]+):\s*([^%]+%) \/([0-9.]+\w+), ([0-9.]*[a-zA-Z\/]+s)*,)"); // Starting with rclone 1.56
     while (mProcess->canReadLine()) {
       QString line = mProcess->readLine().trimmed();
       if (++mLines == 10000) {
@@ -112,8 +117,18 @@ JobWidget::JobWidget(QProcess *process, const QString &info,
         ui.bandwidth->setText(rxSize2.cap(6));
         ui.eta->setText(rxSize2.cap(8));
         ui.totalsize->setText(rxSize2.cap(3) + " " + rxSize2.cap(4));
+      } else if (rxSize3.exactMatch(line)) {
+        ui.size->setText(rxSize3.cap(1) + ", " + rxSize3.cap(3));
+        ui.bandwidth->setText(rxSize3.cap(4));
+        ui.eta->setText(rxSize3.cap(5));
+        ui.totalsize->setText(rxSize3.cap(2));
       } else if (rxErrors.exactMatch(line)) {
         ui.errors->setText(rxErrors.cap(1));
+
+        if (!(rxErrors.cap(1).toInt() == 0)) {
+          ui.errors->setStyleSheet(
+              "QLineEdit { color: red; font-weight: normal;}");
+        }
       } else if (rxChecks.exactMatch(line)) {
         ui.checks->setText(rxChecks.cap(1));
       } else if (rxChecks2.exactMatch(line)) {
@@ -196,39 +211,78 @@ JobWidget::JobWidget(QProcess *process, const QString &info,
         bar->setToolTip("File name: " + name + "\nFile stats" + rxProgress2.cap(0).mid(rxProgress2.cap(0).indexOf(':')));
 
         mUpdated.insert(label);
+      } else if (rxProgress3.exactMatch(line)) {
+        QString name = rxProgress3.cap(1).trimmed();
+
+        auto it = mActive.find(name);
+
+        QLabel *label;
+        QProgressBar *bar;
+        if (it == mActive.end()) {
+          label = new QLabel();
+
+          QString nameTrimmed;
+
+          if (name.length() > 47) {
+            nameTrimmed = name.left(25) + "..." + name.right(19);
+          } else {
+            nameTrimmed = name;
+          }
+
+          label->setText(nameTrimmed);
+
+          bar = new QProgressBar();
+          bar->setMinimum(0);
+          bar->setMaximum(100);
+          bar->setTextVisible(true);
+
+          label->setBuddy(bar);
+
+          ui.progress->addRow(label, bar);
+
+          mActive.insert(name, label);
+        } else {
+          label = it.value();
+          bar = static_cast<QProgressBar *>(label->buddy());
+        }
+
+        bar->setValue(rxProgress3.cap(2).toInt());
+        bar->setToolTip("File name: " + name + "\nFile stats" + rxProgress3.cap(0).mid(rxProgress3.cap(0).indexOf(':')));
+
+        mUpdated.insert(label);
       }
     }
   });
 
-  QObject::connect(mProcess,
-                   static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(
-                       &QProcess::finished),
-                   this, [=](int status, QProcess::ExitStatus) {
-                     mProcess->deleteLater();
-                     for (auto label : mActive) {
-                       ui.progress->removeWidget(label->buddy());
-                       ui.progress->removeWidget(label);
-                       delete label->buddy();
-                       delete label;
-                     }
+    QObject::connect(mProcess,
+      static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(
+          &QProcess::finished),
+      this, [=](int status, QProcess::ExitStatus) {
+        mProcess->deleteLater();
+        for (auto label : mActive) {
+          ui.progress->removeWidget(label->buddy());
+          ui.progress->removeWidget(label);
+          delete label->buddy();
+          delete label;
+        }
 
-                     mRunning = false;
-                     if (status == 0) {
-                       ui.showDetails->setStyleSheet(
-                           "QToolButton { border: 0; color: black; }");
-                       ui.showDetails->setText("Finished");
-                     } else {
-                       ui.showDetails->setStyleSheet(
-                           "QToolButton { border: 0; color: red; }");
-                       ui.showDetails->setText("Error");
-                     }
+        mRunning = false;
+        if (status == 0) {
+          ui.showDetails->setStyleSheet(
+              "QToolButton { border: 0; color: black; }");
+          ui.showDetails->setText("Finished");
+        } else {
+          ui.showDetails->setStyleSheet(
+              "QToolButton { border: 0; color: red; }");
+          ui.showDetails->setText("Error");
+        }
 
-                     ui.cancel->setToolTip("Close");
+        ui.cancel->setToolTip("Close");
 
-                     emit finished(ui.info->text());
-                   });
+        emit finished(ui.info->text());
+      });
 
-  ui.showDetails->setStyleSheet("QToolButton { border: 0; color: green; }");
+  ui.showDetails->setStyleSheet("QToolButton { border: 0; color: green; font-weight: bold;}");
   ui.showDetails->setText("Running");
 }
 


### PR DESCRIPTION
Since rclone v1.56, multiple fields in the job widget are empty due to rclone output changes.

This simple patch fixes this.

Your CI must be broken because these changes don't cause build issues.