### PR TITLE
fix: Homebrew install script in README.md results in 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Build instructions
 *Note: rclone for NetBSD does not support `mount` hence this feature is disabled in Rclone Browser. cgofuse guys did not manage to implement it: [#18][billziss-gh_cgofuse_i18]*
 
 ### macOS
-1.  If you don't have [Homebrew](https://brew.sh/) yet install it `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+1.  If you don't have [Homebrew](https://brew.sh/) yet install it `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`
 2.  You might be asked to install xcode command line tools - do it. This is actuall macOS SDK, headers, and build tools. You don't need full xcode IDE.
 3.  Install dependencies `brew install git cmake rclone qt5`
 4.  Clone source code from this repo `git clone https://github.com/kapitainsky/RcloneBrowser.git`


### PR DESCRIPTION
Just a small correction to the install snippet for homebrew that needed a `.sh` appended to it.